### PR TITLE
Add Git repo reference

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,6 @@
 Package.describe({
-  summary: 'AMQP driver for node'
+  summary: 'AMQP driver for node',
+  git: 'https://github.com/DSpeichert/meteor-amqp'
 });
 
 Npm.depends({


### PR DESCRIPTION
When/if [publishing to Atmosphere](https://atmospherejs.com/i/publishing), don't end up like [this package](https://atmospherejs.com/mrt/amqp) with not attached repo.
